### PR TITLE
Fix `use let` warning

### DIFF
--- a/Sources/EntwineTest/TestScheduler/TestScheduler.swift
+++ b/Sources/EntwineTest/TestScheduler/TestScheduler.swift
@@ -81,7 +81,7 @@ public class TestScheduler {
     /// - Returns: A `TestableSubscriber` that contains, or is scheduled to contain, the output of the publisher subscription.
     public func start<P: Publisher>(configuration: Configuration = .default, create: @escaping () -> P) -> TestableSubscriber<P.Output, P.Failure> {
         
-        var subscriber = createTestableSubscriber(P.Output.self, P.Failure.self, options: configuration.subscriberOptions)
+        let subscriber = createTestableSubscriber(P.Output.self, P.Failure.self, options: configuration.subscriberOptions)
         var source: AnyPublisher<P.Output, P.Failure>!
         
         schedule(after: configuration.created, tolerance: minimumTolerance, options: nil) {


### PR DESCRIPTION
I does not make much difference but it gives me an error on Bitrise saying `variable 'subscriber' was never mutated; consider changing to 'let' constant` so I fixed it.