### PR TITLE
license tweak

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,3 @@
-MIT License
-
-Entwine
-https://github.com/tcldr/Entwine
-
 Copyright © 2019 Tristan Celder. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Updates the license so that Github's identification mechanism correctly identifies this as an MIT license. That in turn flows through to Swift Package Index, which after this is merged should (couple of hours) correctly show the license for this library. (per SwiftPackageIndex/SwiftPackageIndex-Server#669)