### PR TITLE
Relax deployment target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Entwine",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+        .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS(.v3)
     ],
     products: [
         .library(

--- a/Sources/Common/Utilities/SinkQueue.swift
+++ b/Sources/Common/Utilities/SinkQueue.swift
@@ -22,10 +22,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 // MARK: - SinkQueue definition
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class SinkQueue<Sink: Subscriber> {
     
     private var sink: Sink?
@@ -100,3 +103,5 @@ class SinkQueue<Sink: Subscriber> {
         return forwardableDemand
     }
 }
+
+#endif

--- a/Sources/Entwine/Deprecated/CancellableBag.swift
+++ b/Sources/Entwine/Deprecated/CancellableBag.swift
@@ -22,10 +22,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 /// A container for cancellables that will be cancelled when the bag is deallocated or cancelled itself
 @available(*, deprecated, message: "Replace with mutable Set<AnyCancellable>")
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public final class CancellableBag: Cancellable {
     
     public init() {}
@@ -46,9 +49,12 @@ public final class CancellableBag: Cancellable {
 
 // MARK: - Cancellable extension
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Cancellable {
     @available(*, deprecated, message: "Replace CancellableBag with Set<AnyCancellable> and use `store(in:)`")
     func cancelled(by cancellableBag: CancellableBag) {
         cancellableBag.add(self)
     }
 }
+
+#endif

--- a/Sources/Entwine/Deprecated/Deprecations.swift
+++ b/Sources/Entwine/Deprecated/Deprecations.swift
@@ -22,7 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 @available(*, deprecated, message: "Replace with mutable Set<AnyCancellable>")
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public typealias CancellationBag = Set<AnyCancellable>
+
+#endif

--- a/Sources/Entwine/Operators/Dematerialize.swift
+++ b/Sources/Entwine/Operators/Dematerialize.swift
@@ -22,8 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     
     // MARK: - Publisher
@@ -189,6 +192,7 @@ extension Publishers {
 
 // MARK: - Operators
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Output: SignalConvertible, Failure == Never {
     
     private func dematerializedValuesPublisherSequence() -> Publishers.Dematerialize<Self> {
@@ -218,6 +222,7 @@ extension Publisher where Output: SignalConvertible, Failure == Never {
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Failure: DematerializationErrorConvertible {
     
     /// Force unwraps the errors of a dematerialized publisher to return a publisher that matches that of
@@ -269,3 +274,5 @@ public protocol DematerializationErrorConvertible {
 extension DematerializationError: DematerializationErrorConvertible {
     public var dematerializationError: DematerializationError<SourceError> { self }
 }
+
+#endif

--- a/Sources/Entwine/Operators/Materialize.swift
+++ b/Sources/Entwine/Operators/Materialize.swift
@@ -22,8 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     
     // MARK: - Publisher
@@ -138,6 +141,7 @@ extension Publishers {
 
 // MARK: - Operator
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher {
     
     /// Wraps each element from the upstream publisher, as well as its subscription and completion events,
@@ -149,3 +153,5 @@ public extension Publisher {
         Publishers.Materialize(upstream: self)
     }
 }
+
+#endif

--- a/Sources/Entwine/Operators/ReferenceCounted.swift
+++ b/Sources/Entwine/Operators/ReferenceCounted.swift
@@ -22,10 +22,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 // MARK: - Publisher
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     
     /// Automates the process of connecting to a multicast publisher. Connects when the first
@@ -112,6 +115,7 @@ extension Publishers {
 
 // MARK: - Operator
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers.Multicast {
     
     /// Automates the process of connecting to a multicast publisher. Connects when the first
@@ -122,3 +126,5 @@ extension Publishers.Multicast {
         .init(upstream: upstream, createSubject: createSubject)
     }
 }
+
+#endif

--- a/Sources/Entwine/Operators/ReplaySubject.swift
+++ b/Sources/Entwine/Operators/ReplaySubject.swift
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 /// A subject that maintains a buffer of its latest values for replay to new subscribers and passes
@@ -30,6 +32,7 @@ import Combine
 /// The subject passes through elements and completion states unchanged and in addition
 /// replays the latest elements to any new subscribers. Use this subject when you want subscribers
 /// to receive the most recent previous elements in addition to all future elements.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public final class ReplaySubject<Output, Failure: Error> {
     
     typealias Sink = AnySubscriber<Output, Failure>
@@ -50,6 +53,7 @@ public final class ReplaySubject<Output, Failure: Error> {
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension ReplaySubject: Publisher {
     
     public func receive<S : Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
@@ -66,6 +70,7 @@ extension ReplaySubject: Publisher {
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension ReplaySubject: Subject {
     
     public func send(subscription: Subscription) {
@@ -89,6 +94,7 @@ extension ReplaySubject: Subject {
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 fileprivate final class ReplaySubjectSubscription<Sink: Subscriber>: Subscription {
     
     private let queue: SinkQueue<Sink>
@@ -126,6 +132,7 @@ fileprivate final class ReplaySubjectSubscription<Sink: Subscriber>: Subscriptio
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension ReplaySubject {
     
     public static func createUnbounded() -> ReplaySubject<Output, Failure> {
@@ -153,3 +160,5 @@ fileprivate struct ReplaySubjectValueBuffer<Value> {
         }
     }
 }
+
+#endif

--- a/Sources/Entwine/Operators/ShareReplay.swift
+++ b/Sources/Entwine/Operators/ShareReplay.swift
@@ -22,8 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher {
     /// Returns a publisher as a class instance that replays previous values to new subscribers
     ///
@@ -40,3 +43,5 @@ extension Publisher {
         multicast { ReplaySubject<Output, Failure>(maxBufferSize: maxBufferSize) }.referenceCounted()
     }
 }
+
+#endif

--- a/Sources/Entwine/Operators/Signpost.swift
+++ b/Sources/Entwine/Operators/Signpost.swift
@@ -22,9 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 import os.log
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     
     // MARK: - Publisher configuration
@@ -198,6 +201,7 @@ extension Publishers {
 
 // MARK: - Operator
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher {
     
     /// Marks points of interest for your publisher events as time intervals for debugging performance in Instruments.
@@ -213,3 +217,4 @@ public extension Publisher {
     }
 }
 
+#endif

--- a/Sources/Entwine/Operators/WithLatestFrom.swift
+++ b/Sources/Entwine/Operators/WithLatestFrom.swift
@@ -22,8 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     
     /// A publisher that combines the latest value from another publisher with each value from an upstream publisher
@@ -167,6 +170,7 @@ extension Publishers {
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher {
     
     /// Subscribes to an additional publisher and invokes a closure upon receiving output from this
@@ -191,3 +195,5 @@ public extension Publisher {
         withLatest(from: other, transform: { _, b in b })
     }
 }
+
+#endif

--- a/Sources/Entwine/Publishers/Factory.swift
+++ b/Sources/Entwine/Publishers/Factory.swift
@@ -22,8 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     
     /// Creates a simple publisher inline from a provided closure
@@ -77,6 +80,7 @@ extension Publishers {
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 fileprivate class FactorySubscription<Sink: Subscriber>: Subscription {
     
     var subscription: ((Dispatcher<Sink.Input, Sink.Failure>) -> AnyCancellable)?
@@ -108,6 +112,7 @@ fileprivate class FactorySubscription<Sink: Subscriber>: Subscription {
 // MARK: - Public facing Dispatcher defintion
 
 /// Manages a queue of publisher sequence elements to be delivered to a subscriber
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public class Dispatcher<Input, Failure: Error> {
     
     /// Queues an element to be delivered to the subscriber
@@ -143,6 +148,7 @@ public class Dispatcher<Input, Failure: Error> {
 
 // MARK: - Internal Dispatcher defintion
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class FactoryDispatcher<Input, Failure, Sink: Subscriber>: Dispatcher<Input, Failure>
     where Input == Sink.Input, Failure == Sink.Failure
 {
@@ -165,3 +171,5 @@ class FactoryDispatcher<Input, Failure, Sink: Subscriber>: Dispatcher<Input, Fai
         queue.expediteCompletion(completion)
     }
 }
+
+#endif

--- a/Sources/Entwine/Schedulers/TrampolineScheduler.swift
+++ b/Sources/Entwine/Schedulers/TrampolineScheduler.swift
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 import Foundation
 
@@ -51,6 +53,7 @@ public final class TrampolineScheduler {
 
 // MARK: - Scheduler conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TrampolineScheduler: Scheduler {
     
     public typealias SchedulerTimeType = ImmediateScheduler.SchedulerTimeType
@@ -102,3 +105,5 @@ fileprivate final class TrampolineSchedulerQueue {
         status = .idle
     }
 }
+
+#endif

--- a/Sources/Entwine/Signal.swift
+++ b/Sources/Entwine/Signal.swift
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 // MARK: - Signal value definition
@@ -32,6 +34,7 @@ import Combine
 /// - Exactly one 'subscription' signal.
 /// - Followed by zero or more 'input' signals.
 /// - Terminated finally by a single 'completion' signal.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public enum Signal <Input, Failure: Error> {
     /// Sent by a `Publisher` to a `Subscriber` in acknowledgment of the `Subscriber`'s
     /// subscription request.
@@ -46,6 +49,7 @@ public enum Signal <Input, Failure: Error> {
 
 // MARK: - Signal extensions
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Signal {
     /// Whether the signal indicates sequence completion
     var isCompletion: Bool {
@@ -84,6 +88,7 @@ public extension Signal {
 
 // MARK: - Equatable conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Signal: Equatable where Input: Equatable, Failure: Equatable {
     
     public static func ==(lhs: Signal<Input, Failure>, rhs: Signal<Input, Failure>) -> Bool {
@@ -112,6 +117,7 @@ extension Signal: Equatable where Input: Equatable, Failure: Equatable {
 }
 
 /// A type that can be converted into a `Signal`
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public protocol SignalConvertible {
     
     /// The `Input` type of the produced `Signal`
@@ -124,6 +130,7 @@ public protocol SignalConvertible {
     var signal: Signal<Input, Failure> { get }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Signal: SignalConvertible {
     
     public init(_ signal: Signal<Input, Failure>) {
@@ -134,3 +141,5 @@ extension Signal: SignalConvertible {
         return self
     }
 }
+
+#endif

--- a/Sources/Entwine/Utilities/DeallocToken.swift
+++ b/Sources/Entwine/Utilities/DeallocToken.swift
@@ -22,9 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 /// An object that notifies of its deallocation via a publisher sequence
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public final class DeallocToken {
     
     private let subject = PassthroughSubject<(), Never>()
@@ -39,3 +42,5 @@ public final class DeallocToken {
         subject.send(completion: .finished)
     }
 }
+
+#endif

--- a/Sources/EntwineTest/Deprecations.swift
+++ b/Sources/EntwineTest/Deprecations.swift
@@ -22,6 +22,9 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension TestableSubscriber {
     
     @available(*, deprecated, renamed: "recordedOutput")
@@ -30,3 +33,5 @@ public extension TestableSubscriber {
     @available(*, deprecated, renamed: "recordedDemandLog")
     var demands: DemandLedger<VirtualTime>{ recordedDemandLog }
 }
+
+#endif

--- a/Sources/EntwineTest/Signal+CustomDebugStringConvertible.swift
+++ b/Sources/EntwineTest/Signal+CustomDebugStringConvertible.swift
@@ -22,10 +22,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Entwine
 
 // MARK: - CustomDebugStringConvertible conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Signal: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
@@ -38,3 +41,5 @@ extension Signal: CustomDebugStringConvertible {
         }
     }
 }
+
+#endif

--- a/Sources/EntwineTest/TestEvent.swift
+++ b/Sources/EntwineTest/TestEvent.swift
@@ -22,9 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 import Entwine
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 struct TestEvent <Signal: SignalConvertible> {
     
     let time: VirtualTime
@@ -38,12 +41,16 @@ struct TestEvent <Signal: SignalConvertible> {
 
 // MARK: - Equatable conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestEvent: Equatable where Signal: Equatable {}
 
 // MARK: - CustomDebugStringConvertible conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestEvent: CustomDebugStringConvertible {
     public var debugDescription: String {
         return "SignalEvent(\(time), \(signal))"
     }
 }
+
+#endif

--- a/Sources/EntwineTest/TestScheduler/TestScheduler.swift
+++ b/Sources/EntwineTest/TestScheduler/TestScheduler.swift
@@ -26,6 +26,8 @@
 //  Copyright © 2015 Krunoslav Zaher All rights reserved.
 //  https://github.com/ReactiveX/RxSwift
 
+#if canImport(Combine)
+
 import Entwine
 import Combine
 
@@ -37,6 +39,7 @@ import Combine
 /// A special, non thread-safe scheduler for testing operators that require a scheduler without introducing
 /// real concurrency. Faciliates a recreatable sequence of tasks executed within 'virtual time'.
 ///
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public class TestScheduler {
     
     /// Configuration values for  a`TestScheduler` test run.
@@ -197,6 +200,7 @@ public class TestScheduler {
 
 // MARK: - TestScheduler Scheduler conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestScheduler: Scheduler {
     
     public typealias SchedulerTimeType = VirtualTime
@@ -257,3 +261,5 @@ extension TestSchedulerTask: Comparable {
         lhs.id == rhs.id
     }
 }
+
+#endif

--- a/Sources/EntwineTest/TestScheduler/VirtualTime.swift
+++ b/Sources/EntwineTest/TestScheduler/VirtualTime.swift
@@ -22,7 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Combine
 
 // MARK: - VirtualTime value definition
 

--- a/Sources/EntwineTest/TestScheduler/VirtualTimeInterval.swift
+++ b/Sources/EntwineTest/TestScheduler/VirtualTimeInterval.swift
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 // MARK: - VirtualTimeInterval value definition
@@ -155,3 +157,5 @@ extension Int {
         self.init(value._duration)
     }
 }
+
+#endif

--- a/Sources/EntwineTest/TestSequence.swift
+++ b/Sources/EntwineTest/TestSequence.swift
@@ -22,11 +22,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Entwine
 
 // MARK: - TestSequence definition
 
 /// A collection of time-stamped `Signal`s
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct TestSequence <Input, Failure: Error> {
     
     private var contents: [Element]
@@ -61,6 +64,7 @@ public struct TestSequence <Input, Failure: Error> {
 
 // MARK: - Sequence conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestSequence: Sequence {
     
     public typealias Iterator = IndexingIterator<[Element]>
@@ -73,6 +77,7 @@ extension TestSequence: Sequence {
 
 // MARK: - RangeReplaceableCollection conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestSequence: RangeReplaceableCollection {
     
     public typealias Index = Int
@@ -101,6 +106,7 @@ extension TestSequence: RangeReplaceableCollection {
 
 // MARK: - ExpressibleByArrayLiteral conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestSequence: ExpressibleByArrayLiteral {
     
     public typealias ArrayLiteralElement = Element
@@ -112,6 +118,7 @@ extension TestSequence: ExpressibleByArrayLiteral {
 
 // MARK: - Equatable conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestSequence: Equatable where Input: Equatable, Failure: Equatable {
     
     private var events: [TestEvent<Signal<Input, Failure>>] {
@@ -122,3 +129,5 @@ extension TestSequence: Equatable where Input: Equatable, Failure: Equatable {
         lhs.events == rhs.events
     }
 }
+
+#endif

--- a/Sources/EntwineTest/TestablePublisher/TestablePublisher.swift
+++ b/Sources/EntwineTest/TestablePublisher/TestablePublisher.swift
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 import Entwine
 import Foundation
@@ -35,6 +37,7 @@ enum TestablePublisherBehavior { case absolute, relative }
 /// A `Publisher` that produces the elements provided in a `TestSequence`.
 ///
 /// Initializable using the factory methods on `TestScheduler`
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct TestablePublisher<Output, Failure: Error>: Publisher {
     
     private let testScheduler: TestScheduler
@@ -56,6 +59,7 @@ public struct TestablePublisher<Output, Failure: Error>: Publisher {
 
 // MARK: - Subscription definition
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 fileprivate final class TestablePublisherSubscription<Sink: Subscriber>: Subscription {
     
     private let linkedList = LinkedList<Int>.empty
@@ -103,3 +107,5 @@ fileprivate final class TestablePublisherSubscription<Sink: Subscriber>: Subscri
         queue = nil
     }
 }
+
+#endif

--- a/Sources/EntwineTest/TestableSubscriber/DemandLedger.swift
+++ b/Sources/EntwineTest/TestableSubscriber/DemandLedger.swift
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 
 // MARK: - TestSequence definition
@@ -29,6 +31,7 @@ import Combine
 /// A sequence of `Subscribers.Demand` transactions.
 ///
 /// `DemandLedger`'s can be compared to see if they match expectations.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct DemandLedger<Time: Strideable> where Time.Stride : SchedulerTimeIntervalConvertible {
     
     /// The kind of transcation for a `DemandLedger`
@@ -58,6 +61,7 @@ public struct DemandLedger<Time: Strideable> where Time.Stride : SchedulerTimeIn
 
 // MARK: - Sequence conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DemandLedger: Sequence {
     
     public typealias Iterator = IndexingIterator<[Element]>
@@ -70,6 +74,7 @@ extension DemandLedger: Sequence {
 
 // MARK: - RangeReplaceableCollection conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DemandLedger: RangeReplaceableCollection {
     
     public typealias Index = Int
@@ -98,6 +103,7 @@ extension DemandLedger: RangeReplaceableCollection {
 
 // MARK: - ExpressibleByArrayLiteral conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DemandLedger: ExpressibleByArrayLiteral {
     
     public typealias ArrayLiteralElement = Element
@@ -109,6 +115,7 @@ extension DemandLedger: ExpressibleByArrayLiteral {
 
 // MARK: - Equatable conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DemandLedger: Equatable {
     
     public static func == (lhs: DemandLedger<Time>, rhs: DemandLedger<Time>) -> Bool {
@@ -119,6 +126,7 @@ extension DemandLedger: Equatable {
 
 // MARK: - DemandLedgerRow definition
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 fileprivate struct DemandLedgerRow<Time: Strideable>: Equatable where Time.Stride : SchedulerTimeIntervalConvertible {
     
     let time: VirtualTime
@@ -132,6 +140,7 @@ fileprivate struct DemandLedgerRow<Time: Strideable>: Equatable where Time.Strid
     }
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DemandLedger.Transaction: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
@@ -145,6 +154,7 @@ extension DemandLedger.Transaction: CustomDebugStringConvertible {
 
 // MARK: - Subscribers.Demand helper extension
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Subscribers.Demand {
     func prettyDescription() -> String {
         guard let max = max else {
@@ -154,3 +164,4 @@ extension Subscribers.Demand {
     }
 }
 
+#endif

--- a/Sources/EntwineTest/TestableSubscriber/TestableSubscriber.swift
+++ b/Sources/EntwineTest/TestableSubscriber/TestableSubscriber.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import Combine
 import Entwine
 
 // MARK: - TestableSubscriberOptions value definition
 
 /// Options for the defining the behavior of a `TestableSubscriber` throughout its lifetime
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct TestableSubscriberOptions {
     /// The demand that will be signalled to the upstream `Publisher` upon subscription
     public var initialDemand = Subscribers.Demand.unlimited
@@ -56,6 +59,7 @@ public struct TestableSubscriberOptions {
 /// A subscriber that keeps a time-stamped log of the events that occur during the lifetime of a subscription to an arbitrary publisher.
 ///
 /// Initializable using the factory methods on `TestScheduler`
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public final class TestableSubscriber<Input, Failure: Error> {
     
     public typealias Sequence = TestSequence<Input, Failure>
@@ -134,6 +138,7 @@ public final class TestableSubscriber<Input, Failure: Error> {
 
 // MARK: - Subscriber conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestableSubscriber: Subscriber {
     
     public func receive(subscription: Subscription) {
@@ -168,6 +173,7 @@ extension TestableSubscriber: Subscriber {
 
 // MARK: - Cancellable conformance
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TestableSubscriber: Cancellable {
     public func cancel() {
         replenishmentToken?.cancel()
@@ -176,3 +182,5 @@ extension TestableSubscriber: Cancellable {
         replenishmentToken = nil
     }
 }
+
+#endif

--- a/Tests/EntwineTestTests/TestSchedulerTests.swift
+++ b/Tests/EntwineTestTests/TestSchedulerTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class TestSchedulerTests: XCTestCase {
     
     func testSchedulerTasksSortSensibly() {
@@ -308,3 +311,5 @@ final class TestSchedulerTests: XCTestCase {
         ("testRemovesTaskCancelledWithinOwnAction", testRemovesTaskCancelledWithinOwnAction)
     ]
 }
+
+#endif

--- a/Tests/EntwineTestTests/TestablePublisherTests.swift
+++ b/Tests/EntwineTestTests/TestablePublisherTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class TestablePublisherTests: XCTestCase {
     
     struct Token: Equatable {}
@@ -76,3 +79,5 @@ final class TestablePublisherTests: XCTestCase {
         ("testHotObservableProducesExpectedValues", testHotObservableProducesExpectedValues),
     ]
 }
+
+#endif

--- a/Tests/EntwineTestTests/TestableSubscriberTests.swift
+++ b/Tests/EntwineTestTests/TestableSubscriberTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class TestableSubscriberTests: XCTestCase {
     
     struct Token: Equatable {}
@@ -289,3 +292,5 @@ final class TestableSubscriberTests: XCTestCase {
         ("testEnforcesSingleSubscriber", testEnforcesSingleSubscriber),
     ]
 }
+
+#endif

--- a/Tests/EntwineTestTests/XCTestManifests.swift
+++ b/Tests/EntwineTestTests/XCTestManifests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-#if !canImport(ObjectiveC)
+#if !canImport(ObjectiveC) && canImport(Combine)
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(TestSchedulerTests.allTests),

--- a/Tests/EntwineTests/DematerializeTests.swift
+++ b/Tests/EntwineTests/DematerializeTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class DematerializeTests: XCTestCase {
     
     // MARK: - Properties
@@ -103,3 +106,5 @@ final class DematerializeTests: XCTestCase {
         ])
     }
 }
+
+#endif

--- a/Tests/EntwineTests/FactoryTests.swift
+++ b/Tests/EntwineTests/FactoryTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class FactoryTests: XCTestCase {
     
     func testCreatesNever() {
@@ -104,3 +107,5 @@ final class FactoryTests: XCTestCase {
         ])
     }
 }
+
+#endif

--- a/Tests/EntwineTests/MaterializeTests.swift
+++ b/Tests/EntwineTests/MaterializeTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class MaterializeTests: XCTestCase {
     
     // MARK: - Properties
@@ -87,3 +90,5 @@ final class MaterializeTests: XCTestCase {
         XCTAssertEqual(expected1, results1.recordedOutput)
     }
 }
+
+#endif

--- a/Tests/EntwineTests/ReferenceCountedTests.swift
+++ b/Tests/EntwineTests/ReferenceCountedTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class ReferenceCountedTests: XCTestCase {
     
     // MARK: - Properties
@@ -130,3 +133,5 @@ final class ReferenceCountedTests: XCTestCase {
         sut.multicast(factory).autoconnect().sink { print("B:\($0)") }.store(in: &cancellables)
     }
 }
+
+#endif

--- a/Tests/EntwineTests/ReplaySubjectTests.swift
+++ b/Tests/EntwineTests/ReplaySubjectTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class ReplaySubjectTests: XCTestCase {
     
     // MARK: - Properties
@@ -539,6 +542,7 @@ final class ReplaySubjectTests: XCTestCase {
 
 // MARK: - Test types
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 fileprivate final class TestSubscription: Subscription {
     func request(_ demand: Subscribers.Demand) {
         self.demand = demand
@@ -551,3 +555,5 @@ fileprivate final class TestSubscription: Subscription {
     var cancelled = false
     var demand: Subscribers.Demand?
 }
+
+#endif

--- a/Tests/EntwineTests/ShareReplayTests.swift
+++ b/Tests/EntwineTests/ShareReplayTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class ShareReplayTests: XCTestCase {
     
     // MARK: - Properties
@@ -288,3 +291,5 @@ final class ShareReplayTests: XCTestCase {
         XCTAssertEqual(expected2, results2.recordedOutput)
     }
 }
+
+#endif

--- a/Tests/EntwineTests/TrampolineSchedulerTests.swift
+++ b/Tests/EntwineTests/TrampolineSchedulerTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class TrampolineSchedulerTests: XCTestCase {
     
     func testSchedulerTrampolinesActions() {
@@ -106,3 +109,5 @@ final class TrampolineSchedulerTests: XCTestCase {
         XCTAssertEqual(expected, results.recordedOutput)
     }
 }
+
+#endif

--- a/Tests/EntwineTests/WithLatestFromTests.swift
+++ b/Tests/EntwineTests/WithLatestFromTests.swift
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(Combine)
+
 import XCTest
 import Combine
 
 @testable import Entwine
 @testable import EntwineTest
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class WithLatestFromTests: XCTestCase {
     
     func testTakesOnlyLatestValueFromOther() {
@@ -139,3 +142,5 @@ final class WithLatestFromTests: XCTestCase {
         
     }
 }
+
+#endif


### PR DESCRIPTION
Relax Deploymaent Target limits for more flexibility in development.

Related: https://github.com/CombineCommunity/CombineExt/pull/29, https://github.com/pointfreeco/combine-schedulers/pull/3