### PR TITLE
Advance scheduler to specific time

### DIFF
--- a/Sources/EntwineTest/TestScheduler/TestScheduler.swift
+++ b/Sources/EntwineTest/TestScheduler/TestScheduler.swift
@@ -196,6 +196,32 @@ public class TestScheduler {
         lastTaskId += 1
         return lastTaskId
     }
+
+    /// Performs all the actions in the scheduler's queue  until reaches to the duration that is added as virtual time from now
+    /// - Parameters:
+    ///   - duration: The `CombineTestTimeInterval` that are going to be performed all tasks until by adding interval from now
+    public func advance(by duration: VirtualTimeInterval) {
+        advance(to: now.advanced(by: duration))
+    }
+
+    /// Performs all the actions in the scheduler's queue, in time  until reaches to the duration
+    /// - Parameters:
+    ///   - instant: The `CombineTestTime` that are going to be performed all tasks until
+    public func advance(to instant: VirtualTime) {
+        while now <= instant {
+            guard
+                let next = findNext(),
+                instant >= next.time
+            else {
+                currentTime = instant
+                return
+            }
+
+            currentTime = next.time
+            schedulerQueue.remove(next)
+            next.action()
+        }
+    }
 }
 
 // MARK: - TestScheduler Scheduler conformance

--- a/Sources/EntwineTest/TestScheduler/TestScheduler.swift
+++ b/Sources/EntwineTest/TestScheduler/TestScheduler.swift
@@ -199,14 +199,14 @@ public class TestScheduler {
 
     /// Performs all the actions in the scheduler's queue  until reaches to the duration that is added as virtual time from now
     /// - Parameters:
-    ///   - duration: The `CombineTestTimeInterval` that are going to be performed all tasks until by adding interval from now
+    ///   - duration: The `VirtualTimeInterval` that are going to be performed all tasks until by adding interval from now
     public func advance(by duration: VirtualTimeInterval) {
         advance(to: now.advanced(by: duration))
     }
 
     /// Performs all the actions in the scheduler's queue, in time  until reaches to the duration
     /// - Parameters:
-    ///   - instant: The `CombineTestTime` that are going to be performed all tasks until
+    ///   - instant: The `VirtualTime` that are going to be performed all tasks until
     public func advance(to instant: VirtualTime) {
         while now <= instant {
             guard

--- a/Tests/EntwineTestTests/TestSchedulerTests.swift
+++ b/Tests/EntwineTestTests/TestSchedulerTests.swift
@@ -337,7 +337,9 @@ final class TestSchedulerTests: XCTestCase {
         ("testTrampolinesImmediatelyScheduledTasks", testTrampolinesImmediatelyScheduledTasks),
         ("testSchedulesRepeatingTask", testSchedulesAndCancelsRepeatingTask),
         ("testIgnoresTasksAfterMaxClock", testIgnoresTasksAfterMaxClock),
-        ("testRemovesTaskCancelledWithinOwnAction", testRemovesTaskCancelledWithinOwnAction)
+        ("testRemovesTaskCancelledWithinOwnAction", testRemovesTaskCancelledWithinOwnAction),
+        ("testSchedulerAdvancesToTasksTime", testSchedulerAdvancesToTasksTime),
+        ("testSchedulerAdvancesToTasksByTimeInterval", testSchedulerAdvancesToTasksByTimeInterval)
     ]
 }
 

--- a/Tests/EntwineTestTests/TestSchedulerTests.swift
+++ b/Tests/EntwineTestTests/TestSchedulerTests.swift
@@ -77,7 +77,36 @@ final class TestSchedulerTests: XCTestCase {
         
         XCTAssertEqual(times, [100, 200, 300,])
     }
-    
+
+    func testSchedulerAdvancesToTasksTime() {
+
+        let subject = TestScheduler(initialClock: 0)
+        var changedValue = 0
+
+        subject.schedule(after: 300) { changedValue = 300 }
+        subject.schedule(after: 200) { changedValue = 200 }
+        subject.schedule(after: 100) { changedValue = 100 }
+
+        subject.advance(to: 200)
+
+        XCTAssertEqual(changedValue, 200)
+    }
+
+    func testSchedulerAdvancesToTasksByTimeInterval() {
+
+        let subject = TestScheduler(initialClock: 0)
+        var changedValue = 0
+
+        subject.schedule(after: 300) { changedValue = 300 }
+        subject.schedule(after: 200) { changedValue = 200 }
+        subject.schedule(after: 100) { changedValue = 100 }
+
+        subject.advance(to: 100)
+        XCTAssertEqual(changedValue, 100)
+        subject.advance(by: 100)
+        XCTAssertEqual(changedValue, 200)
+    }
+
     func testSchedulerInvokesDeferredTask() {
         
         let subject = TestScheduler(initialClock: 0)


### PR DESCRIPTION
Why? 
Sometimes we would like to test some non-published variable values based on given time.

Example:
```swift
apiClient.fetchQuestions()
    .receive(on: scheduler)
    .sink { [weak self] completion in
        switch completion {
        case .finished: 
            print("finished fetching info")
        case .failure(let error):
           // Lets assume error message is not published value and need to be tested at certain given time.
            self?.errorMessage = error.localizedDescription 
        }
    } receiveValue: { [weak self] response in
        self?.questions = response.questions
    }
    .store(in: &cancellables)
```

Now with advance(to:) function we can easily verify the value of variables at given time.

```swift
 context("WHEN api call failed") {
    beforeEach {
        setupSUT {
            mockClient.fetchQuestionsEvents = [ (100, .completion(.failure(.connection))) ]
        }
   }
   it("has error message") {
        scheduler.advance(to: 50)
        expect(sut.errorMessage).to(beNil())
        scheduler.advance(to: 100)
        expect(sut.errorMessage).to(equal(NetworkingError.connection.localizedDescription))
    }
}
```
